### PR TITLE
Set the current private label

### DIFF
--- a/spec/controllers/private_labels/admin/sidebars_controller_spec.rb
+++ b/spec/controllers/private_labels/admin/sidebars_controller_spec.rb
@@ -12,7 +12,7 @@ module PrivateLabels
         let(:admin) { create :confirmed_person }
 
         before(:each) do
-          @request.host = private_label.domain
+          Swayze.current_private_label = private_label
           create(:private_label_person, person: admin, private_label: private_label, admin: true)
           sign_in admin
         end
@@ -44,7 +44,7 @@ module PrivateLabels
         let(:admin) { create :confirmed_person }
 
         before(:each) do
-          @request.host = private_label.domain
+          Swayze.current_private_label = private_label
           create(:private_label_person, person: admin, private_label: private_label, admin: true)
           sign_in admin
         end
@@ -64,7 +64,7 @@ module PrivateLabels
         let(:admin) { create :confirmed_person }
 
         before(:each) do
-          @request.host = private_label.domain
+          Swayze.current_private_label = private_label
           create(:private_label_person, person: admin, private_label: private_label, admin: true)
           sign_in admin
         end


### PR DESCRIPTION
Can't set it in the request in the specs any longer, because the
Constraint that sets the current private label isn't hit during spec
runs.