### PR TITLE
Make sure the conversation starter always appears below the image and

### DIFF
--- a/app/views/private_labels/conversations/partials/_conversation_content.html.erb
+++ b/app/views/private_labels/conversations/partials/_conversation_content.html.erb
@@ -1,15 +1,19 @@
 <section>
-  <% if @conversation.image.present? %>
-    <div class="convo-img">
-      <%= image_tag @conversation.image.url(:panel) %>
+  <div class="row">
+    <% if @conversation.image.present? %>
+      <div class="convo-img">
+        <%= image_tag @conversation.image.url(:panel) %>
+      </div>
+    <% end %>
+    <%= sanitize @conversation.summary %>
+  </div>
+
+  <% if !@conversation.starter.blank? %>
+    <div class="row">
+      <div class="convo-starter">
+        <h2>Conversation Starter</h2>
+        <%= sanitize @conversation.starter %>
+      </div>
     </div>
   <% end %>
-	<%= sanitize @conversation.summary %>
-
-	<% if !@conversation.starter.blank? %>
-		<div class="convo-starter">
-			<h2>Conversation Starter</h2>
-			<%= sanitize @conversation.starter %>
-		</div>
-	<% end %>
 </section>


### PR DESCRIPTION
Ensure that the conversation starter always appears below the conversation image and summary, even if that summary is shorter than the image.