### PR TITLE
Added tinymce editor to precompile

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Civiccommons::Application.configure do
   config.assets.precompile << %w( reset.css master.css ie.css petition.print.css admin.css widget.css _bootstrap.css)
 
   config.assets.precompile << "tinymce/themes/advanced/skins/private_label/*.css"
+  config.assets.precompile << "tinymce/plugins/plugins/mention/editor_plugin.js"
 
   config.angular_templates.ignore_prefix = ['embed/ng/templates/', 'templates'] if config.angular_templates
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -62,6 +62,7 @@ Civiccommons::Application.configure do
   config.assets.precompile << %w( reset.css master.css ie.css petition.print.css admin.css widget.css _bootstrap.css)
 
   config.assets.precompile << "tinymce/themes/advanced/skins/private_label/*.css"
+  config.assets.precompile << "tinymce/plugins/plugins/mention/editor_plugin.js"
 
   config.angular_templates.ignore_prefix = ['embed/ng/templates/', 'templates'] if config.angular_templates
 


### PR DESCRIPTION
Added a line to force the editor js into the precompile step. This should resolve the missing comment box issue in staging. 