### PR TITLE
Admin Sidebar Changes

### DIFF
--- a/app/assets/stylesheets/private_label/sidebar.css.scss
+++ b/app/assets/stylesheets/private_label/sidebar.css.scss
@@ -6,7 +6,7 @@
 		min-height: 150px;
 		margin-bottom: 30px;
 		box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.2);
-		
+		padding: 10px 20px;
 	}
 }
 .private_labels-homepage{

--- a/app/controllers/private_labels/admin/sidebars_controller.rb
+++ b/app/controllers/private_labels/admin/sidebars_controller.rb
@@ -15,7 +15,8 @@ module PrivateLabels
 
       def update
         @sidebar.update_attributes sidebar_params
-        redirect_to private_labels_admin_root_path
+        flash[:notice] = "Sidebar content has been updated"
+        redirect_to :back
       end
 
       protected

--- a/app/views/private_labels/admin/sidebars/edit.html.erb
+++ b/app/views/private_labels/admin/sidebars/edit.html.erb
@@ -1,9 +1,17 @@
 <h1>Sidebar</h1>
 
 <%= form_for @sidebar, url: private_labels_admin_sidebar_path, namespace: :admin do |f| %>
-  <p class="help-block">The sidebar content is optional for all static pages. You can enter HTML and it will appear on the page correctly.</p>
+  <p class="help-block">The sidebar content is optional for all static pages. You can enter HTML and it will appear on the page correctly. The sidebar will be 360 pixels by default, but is responsive so size will change.</p>
   <div class="form-group">
   	<%= f.text_area :content, :class => 'form-control' %><br />
   </div>
   <%= f.submit 'Submit', :class => 'btn btn-success' %>
 <% end %>
+
+<script type="text/javascript">
+	$(function() {
+   $('.notice').delay(500).fadeIn('normal', function() {
+      $(this).delay(5000).fadeOut();
+   });
+});
+</script>

--- a/spec/controllers/private_labels/admin/sidebars_controller_spec.rb
+++ b/spec/controllers/private_labels/admin/sidebars_controller_spec.rb
@@ -13,6 +13,7 @@ module PrivateLabels
         Swayze.current_private_label = private_label
         create(:private_label_person, person: admin, private_label: private_label, admin: true)
         sign_in admin
+        request.env["HTTP_REFERER"] = "edit sidebar"
       end
 
       context 'GET #edit' do
@@ -55,7 +56,8 @@ module PrivateLabels
           put 'update', sidebar: { content: 'Test sidebar content' }
           expect(assigns(:sidebar)).to be_persisted
           expect(assigns(:sidebar).content).to eq('Test sidebar content')
-          expect(response).to redirect_to(private_labels_admin_root_path)
+          expect(response).to redirect_to "edit sidebar"
+          expect(flash[:notice]).to be_present
         end
 
       end


### PR DESCRIPTION
https://trello.com/c/pTP0oWQc/125-private-label-admin-sidebar-content

- Removed redirection when editing sidebar content
- Added flash notice and timer on notice to alert changes being made.
- Added 20px padding to both sides in the sidebar.