### PR TITLE
Bug/151 Conversation Starter Spacing

### DIFF
--- a/app/views/private_labels/conversations/partials/_conversation_content.html.erb
+++ b/app/views/private_labels/conversations/partials/_conversation_content.html.erb
@@ -1,18 +1,20 @@
 <section>
-  <div>
-    <% if @conversation.image.present? %>
-      <div class="convo-img">
-        <%= image_tag @conversation.image.url(:panel) %>
-      </div>
-    <% end %>
-    <%= simple_format @conversation.summary %>
-  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <% if @conversation.image.present? %>
+        <div class="convo-img">
+          <%= image_tag @conversation.image.url(:panel) %>
+        </div>
+      <% end %>
+      <%= simple_format @conversation.summary %>
 
-  <% if @conversation.link %>
-    <div class="conversation-link">
-      Link: <%= link_to @conversation.link, @conversation.link %>
+      <% if @conversation.link %>
+        <div class="conversation-link">
+          Link: <%= link_to @conversation.link, @conversation.link %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 
   <% if !@conversation.starter.blank? %>
       <div class="convo-starter">

--- a/app/views/private_labels/conversations/show.html.erb
+++ b/app/views/private_labels/conversations/show.html.erb
@@ -22,7 +22,7 @@
 		<%= render partial: 'private_labels/conversations/partials/conversation_content' %>
     <%= render partial: 'private_labels/conversations/partials/conversation_contribute_form' %>
     <%= render partial: 'private_labels/conversations/partials/conversation_contributions' %>
-		
+
 	</div>
 </div>
 
@@ -44,5 +44,4 @@
       <%= render partial: 'private_labels/shared/sidebars/conversation_recent_activities' %>
     </div>
   </div>
-  
 <% end %>


### PR DESCRIPTION
https://trello.com/c/K8qapVjk/151-private-label-ensure-that-conversation-starter-appears-below-images-even-if-content-is-very-short

-Added Row for conversation image and summary to ensure spacing with starter