### PR TITLE
Change Remote Page Contribution Routing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bower-rails (0.8.3)
+    bower-rails (0.9.2)
     builder (3.0.4)
     cancan (1.6.10)
     carrierwave (0.10.0)

--- a/app/controllers/api/v1/remote_pages/contributions_controller.rb
+++ b/app/controllers/api/v1/remote_pages/contributions_controller.rb
@@ -1,0 +1,53 @@
+class Api::V1::RemotePages::ContributionsController < Api::V1::BaseController
+  load_resource :remote_page
+  load_and_authorize_resource :contribution, through: [:remote_page]
+
+  before_filter :update_embedly_attributes, only: [:create, :update]
+
+  def index
+    @contributions = @contributions.where(parent_id: nil).includes(:person, children: [:person]).order("created_at DESC").paginate(page: params[:page], per_page: 20)
+  end
+
+  def create
+    @contribution.confirmed = true
+    @contribution.save!
+    render 'show'
+  end
+
+  def update
+    empty_user unless current_person
+    @contribution.update_attributes params[:contribution]
+    render 'show'
+  end
+
+  def destroy
+    if @contribution.destroy
+      render json: {
+        success: true
+      }
+    end
+  end
+
+  def flag
+    Tos.send_violation_complaint (current_person || Person.new), @contribution, (params[:reason] || 'No Reason Given')
+    render json: {
+      success: true
+    }
+  end
+
+  def moderate
+    @contribution.moderate_content(params[:reason], current_person)
+    render :show
+  end
+
+  private
+
+  def update_embedly_attributes
+    unless @contribution.url.blank?
+      embedly = EmbedlyService.new
+      embedly.fetch_and_update_attributes(@contribution)
+    end
+  end
+
+
+end

--- a/app/views/api/v1/remote_pages/contributions/_contribution.json.jbuilder
+++ b/app/views/api/v1/remote_pages/contributions/_contribution.json.jbuilder
@@ -1,0 +1,18 @@
+json.(contribution, :id, :content, :created_at, :parent_id, :url)
+
+if contribution.attachment_file_name
+  json.attachment contribution.attachment.url :medium
+  json.attachment_full contribution.attachment.url :full
+end
+
+if contribution.embedly_code
+  json.embed JSON.parse(contribution.embedly_code)['oembed'].select { |k,v| ['title', 'description', 'url', 'provider_name', 'provider_url', 'thumbnail_url'].include? k }
+end
+
+json.owner_id contribution.owner
+
+if contribution.parent_id.blank?
+  json.set! :contributions do
+    json.partial! 'api/v1/contributions/contribution', collection: contribution.descendants, as: :contribution
+  end
+end

--- a/app/views/api/v1/remote_pages/contributions/_contributions.json.jbuilder
+++ b/app/views/api/v1/remote_pages/contributions/_contributions.json.jbuilder
@@ -1,0 +1,3 @@
+json.contributions do
+  json.partial! 'api/v1/contributions/contribution', collection: @contributions, as: :contribution
+end

--- a/app/views/api/v1/remote_pages/contributions/index.json.jbuilder
+++ b/app/views/api/v1/remote_pages/contributions/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.cache! [:api, :v1, contributable, contributable.updated_at, params[:page]] do
+  json.total @contributions.count
+  json.partial! 'api/v1/contributions/contributions', contributions: @contributions
+end

--- a/app/views/api/v1/remote_pages/contributions/show.json.jbuilder
+++ b/app/views/api/v1/remote_pages/contributions/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/v1/contributions/contribution', contribution: @contribution

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,4 +42,6 @@ Civiccommons::Application.configure do
 
   config.angular_templates.ignore_prefix = ['embed/ng/templates/', 'templates']
 
+  config.assets.precompile = [ Proc.new{ |path| !File.extname(path).in?(['.js', '.css', '.map', '.gzip']) }, /(?:\/|\\|\A)application\.(css|js)$/ ]
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,7 +340,7 @@ Civiccommons::Application.routes.draw do
         resources :users
       end
       resources :remote_pages do
-        resources :contributions do
+        resources :contributions, controller: "remote_pages/contributions" do
           member do
             post :flag
             post :moderate


### PR DESCRIPTION
There's a bug where contributions aren't loading for remote pages. This seems to happen on all remote pages. I moved the loading of those contributions to another controller and removed the dependency on conversation which doesn't always exist with a remote page.