### PR TITLE
Allow Sites to more directly control duplicate remote embeds

### DIFF
--- a/app/assets/javascripts/embed/ng/application.coffee
+++ b/app/assets/javascripts/embed/ng/application.coffee
@@ -57,7 +57,11 @@ civicApp
               CivicApi.setVar 'contributable_type', 'remote_pages'
               CivicApi.setVar 'contributable_id', page.id
 
-            RemotePage.get {remote_page_url: $route.current.params.remotePageAddress}, (data) ->
+            RemotePage.get {
+              remote_page_url: $route.current.params.remotePageAddress,
+              root_domain: $route.current.params.rootDomain,
+              source_key: $route.current.params.sourceKey
+            }, (data) ->
               unless data.conversation
                 deferred.resolve data
               else

--- a/app/controllers/api/v1/remote_pages_controller.rb
+++ b/app/controllers/api/v1/remote_pages_controller.rb
@@ -1,8 +1,13 @@
 class Api::V1::RemotePagesController < Api::V1::BaseController
-  before_filter :get_remote_page_from_url, only: [:index]
+  # before_filter :get_remote_page_from_url, only: [:index]
   before_filter :get_remote_page, only: [:show, :edit, :delete]
 
   def index
+    if params[:source_key].present?
+      get_remote_page_from_source_key
+    else
+      get_remote_page_from_url
+    end
   end
 
   def show
@@ -12,7 +17,22 @@ class Api::V1::RemotePagesController < Api::V1::BaseController
   def get_remote_page_from_url
     return unless params[:remote_page_url]
     uri = URI.parse params[:remote_page_url]
-    @remote_page = RemotePage.find_or_create_by_url uri.normalize.to_s
+    @remote_page = RemotePage.find_or_create_by_url uri.normalize.to_s do |r|
+      r.source_key = params[:source_key] || ""
+      r.root_domain = params[:root_domain] || ""
+    end
+
+    redirect_to ['api', 'v1', @remote_page]
+  end
+
+  def get_remote_page_from_source_key
+    return unless params[:source_key]
+    uri = URI.parse params[:remote_page_url]
+    root_domain = params[:root_domain] || uri.host
+    @remote_page = RemotePage.find_or_create_by_source_key_and_root_domain(params[:source_key], root_domain) do |r|
+      r.url = params[:remote_page_url] || ""
+    end
+
     redirect_to ['api', 'v1', @remote_page]
   end
 

--- a/app/models/remote_page.rb
+++ b/app/models/remote_page.rb
@@ -1,5 +1,5 @@
 class RemotePage < ActiveRecord::Base
-  attr_accessible :description, :title, :url, :conversation
+  attr_accessible :description, :title, :url, :conversation, :source_key, :root_domain
 
   belongs_to :conversation
 
@@ -7,6 +7,8 @@ class RemotePage < ActiveRecord::Base
   has_many :participants, through: :contributions, source: :person, order: 'contributions.created_at DESC'
 
   alias_method :contributors, :participants
+
+  before_create :set_root_domain
   after_create :create_embeddly_info
 
   def top_level_contributions
@@ -19,6 +21,16 @@ class RemotePage < ActiveRecord::Base
     unless info.blank?
       update_attributes title: info[:title], description: info[:description]
     end
+  end
+
+  def set_root_domain
+    return if self.root_domain.present?
+    return if self.remote_page_url.blank?
+
+    uri = URI.parse self.remote_page_url
+    return if url.nil?
+
+    self.root_domain = uri.host
   end
 
 end

--- a/app/views/embed/index.js.coffee
+++ b/app/views/embed/index.js.coffee
@@ -29,6 +29,8 @@ embedObj = ->
     host: null
     embedType: 'comments'
     remotePageAddress: window.location.href
+    sourceKey: ''
+    rootDomain: ''
     autoInit: true
   @log = (message) ->
     logArr = ['Civic Embed: '].concat arguments
@@ -72,7 +74,10 @@ embedObj = ->
     src.push "#{@settings.host}/embed/"
     src.push "#{@settings.embedType}/" if @settings.embedType in availableEmbedTypes
     src.push @settings.conversationId if @settings.conversationId
-    src.push "?remotePageAddress=#{@settings.remotePageAddress}" if @settings.remotePageAddress
+    src.push "?" if @settings.remotePageAddress || @settings.rootDomain || @settings.sourceKey
+    src.push "remotePageAddress=#{@settings.remotePageAddress}&" if @settings.remotePageAddress
+    src.push "rootDomain=#{@settings.rootDomain}&" if @settings.rootDomain
+    src.push "sourceKey=#{@settings.sourceKey}&" if @settings.sourceKey
     iframe.style.border = @settings.borderStyling
     iframe.style.width = "100%"
 

--- a/app/views/embed/test_comments.html.erb
+++ b/app/views/embed/test_comments.html.erb
@@ -1,3 +1,3 @@
 <% content_for :main_body do %>
-  <iframe src="<%= "/embed/comments?remotePageAddress=#{@url}" %>" style="height: 589px; border: 0px none; width: <%= params[:frame_width] || 100 %>%;"></iframe>
+  <iframe src="<%= "/embed/comments?remotePageAddress=#{@url}&sourceKey=abc123&rootDomain=mysite.com" %>" style="height: 589px; border: 0px none; width: <%= params[:frame_width] || 100 %>%;"></iframe>
 <% end %>

--- a/db/migrate/20150918135113_add_source_key_and_root_domain_to_remote_page.rb
+++ b/db/migrate/20150918135113_add_source_key_and_root_domain_to_remote_page.rb
@@ -1,0 +1,6 @@
+class AddSourceKeyAndRootDomainToRemotePage < ActiveRecord::Migration
+  def change
+    add_column :remote_pages, :source_key, :string
+    add_column :remote_pages, :root_domain, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150629002217) do
+ActiveRecord::Schema.define(:version => 20150918135113) do
 
   create_table "actions", :force => true do |t|
     t.integer  "conversation_id"
@@ -734,6 +734,8 @@ ActiveRecord::Schema.define(:version => 20150629002217) do
     t.datetime "created_at",      :null => false
     t.datetime "updated_at",      :null => false
     t.integer  "conversation_id"
+    t.string   "source_key"
+    t.string   "root_domain"
   end
 
   create_table "revision_records", :force => true do |t|


### PR DESCRIPTION
This feature allows a client of the embed to either use the default remotePageAddress field or override it with the combination of sourceKey and rootDomain. Using the later will cause civic to search on those keys. This was requested by ideastream to fix a situation where the same article is posted on multiple subdomains but with different embeds. 